### PR TITLE
Add eclipse-ide website and Twitter/X name

### DIFF
--- a/otterdog/eclipse-ide.jsonnet
+++ b/otterdog/eclipse-ide.jsonnet
@@ -5,6 +5,8 @@ orgs.newOrg('eclipse-ide') {
     billing_email: "thomas.froment@eclipse-foundation.org",
     default_repository_permission: "write",
     description: "This is both the official community entry point and the starting place for new contributors to the Eclipse IDE and platform-related projects.",
+    blog: "https://eclipseide.org/",
+    twitter_username: "EclipseJavaIDE",
     members_can_create_teams: true,
     name: "Eclipse IDE",
     web_commit_signoff_required: false,


### PR DESCRIPTION
Similar to https://github.com/eclipse-platform/.eclipsefdn/blob/main/otterdog/eclipse-platform.jsonnet, add the eclipse-ide website and Twitter/X name.
Don't add an email since there is no Mailing-List that is dedicated for the entire Eclipse-IDE/SimRel and newcomers.