### PR TITLE
Disable issues for .github repository

### DIFF
--- a/otterdog/eclipse-ide.jsonnet
+++ b/otterdog/eclipse-ide.jsonnet
@@ -16,8 +16,7 @@ orgs.newOrg('eclipse-ide') {
   },
   _repositories+:: [
     orgs.newRepo('.github') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
+      has_issues : false,
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
     },


### PR DESCRIPTION
Additionally forbid merge-commits and permit branch-updates.

@opcoach, @tfroment since we don't want issues to be reported in https://github.com/eclipse-ide/.github (at least at the moment), this disables it.

And applies further small alignments I found useful and that are used in other Eclipse SDK repos.