### PR TITLE
Add 'contributing' repository to eclipse-ide organization

### DIFF
--- a/otterdog/eclipse-ide.jsonnet
+++ b/otterdog/eclipse-ide.jsonnet
@@ -21,5 +21,9 @@ orgs.newOrg('eclipse-ide') {
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
     },
+    orgs.newRepo('contributing') {
+      has_issues : true,
+      has_discussions : true,
+    },
   ],
 }


### PR DESCRIPTION
We would like to add a repository named `contributing` to this organization.

It is intended to be a issue and discussions only repository because the code respectively the documentation lives in https://github.com/eclipse-ide/.github (mainly for technical reasons).

Can you tell if it's possible to disable Pull-Requests for a repository?